### PR TITLE
Add tests for PreferenceHelper

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -6,4 +6,7 @@
   <component name="Kotlin2JvmCompilerArguments">
     <option name="jvmTarget" value="1.8" />
   </component>
+  <component name="KotlinJpsPluginSettings">
+    <option name="version" value="1.7.20" />
+  </component>
 </project>

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -19,7 +19,8 @@ ext {
     ]
 
     androidxTest = [
-            runner : "1.5.2"
+            runner : "1.5.2",
+            core : "1.5.0"
     ]
 
     ktx = [
@@ -29,5 +30,10 @@ ext {
 
     squareup = [
             leakcanary : "2.10"
+    ]
+
+    testLibs = [
+            mockitoAndroid : "4.5.1",
+            mockitoKotlin : "4.0.0"
     ]
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -19,6 +19,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.compileSdkVersion
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        multiDexEnabled true
     }
     compileOptions {
         sourceCompatibility javaVersion
@@ -52,11 +53,15 @@ android {
     namespace 'com.vorlonsoft.android.rate'
 }
 dependencies {
-    compileOnly "androidx.annotation:annotation:${androidx.annotation}"
-    api "androidx.appcompat:appcompat:${androidx.appcompat}"
+
+    androidTestImplementation "org.mockito.kotlin:mockito-kotlin:${testLibs.mockitoKotlin}"
+    androidTestImplementation "org.mockito:mockito-android:${testLibs.mockitoAndroid}"
+    androidTestImplementation "androidx.test:core:${androidxTest.core}"
     androidTestImplementation "androidx.test:runner:${androidxTest.runner}"
+
+    api "androidx.appcompat:appcompat:${androidx.appcompat}"
+
     // Kotlin
-    implementation "androidx.core:core-ktx:${ktx.core}"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:${ktx.coroutines}"
     implementation "com.google.android.play:review:${google.review}"
 }

--- a/library/src/androidTest/java/com/vorlonsoft/android/rate/PreferenceHelperTest.kt
+++ b/library/src/androidTest/java/com/vorlonsoft/android/rate/PreferenceHelperTest.kt
@@ -1,0 +1,314 @@
+package com.vorlonsoft.android.rate
+
+import androidx.test.platform.app.InstrumentationRegistry
+import com.vorlonsoft.android.rate.test_util.PreferencesTestEnv
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Date
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+
+class PreferenceHelperTest {
+
+    companion object {
+        private const val CUSTOM_TEST_EVENT = "CUSTOM_TEST_EVENT"
+    }
+
+    private val prefsEnv = PreferencesTestEnv()
+
+    @Test
+    fun testDefault() {
+        PreferenceHelper(
+            InstrumentationRegistry.getInstrumentation().context,
+            prefsEnv.testSharedPreferencesProvider
+        ).also { underTest ->
+            assertTrue(underTest.isFirstLaunch())
+            assertEquals(0.toShort(), underTest.get365DayPeriodDialogLaunchTimes())
+            assertEquals(false, underTest.getAgreedOrDeclined())
+            assertEquals(0, underTest.getInstallDate())
+            assertEquals(0.toShort(), underTest.getRemindLaunchesNumber())
+            assertEquals(0, underTest.getLastTimeShown())
+            assertEquals(0, underTest.getDialogFirstLaunchTime())
+            assertEquals(PreferenceHelper.UNSET_DELAY_DATE, underTest.getDelay())
+            assertEquals(0, underTest.getCustomEventCount("").toInt())
+        }
+    }
+
+    @Test
+    fun testFirstLaunch() {
+        val context = InstrumentationRegistry.getInstrumentation().context
+        PreferenceHelper(context, prefsEnv.testSharedPreferencesProvider).also { underTest ->
+            underTest.setFirstLaunchSharedPreferences(context)
+            assertEquals(
+                PreferenceHelper.DEFAULT_DIALOG_LAUNCH_TIMES,
+                prefsEnv.testSharedPreferences.getString(
+                    PreferenceHelper.PREF_KEY_365_DAY_PERIOD_DIALOG_LAUNCH_TIMES,
+                    null
+                )
+            )
+            assertEquals(
+                1,
+                prefsEnv.testSharedPreferences.getInt(PreferenceHelper.PREF_KEY_LAUNCH_TIMES, -1)
+            )
+            assertTrue(
+                prefsEnv.testSharedPreferences.getLong(
+                    PreferenceHelper.PREF_KEY_INSTALL_DATE,
+                    -1
+                ) > 0
+            )
+        }
+    }
+
+    @Test
+    fun testCustomEvent() {
+        PreferenceHelper(
+            InstrumentationRegistry.getInstrumentation().context,
+            prefsEnv.testSharedPreferencesProvider
+        ).also { underTest ->
+            assertEquals(0, underTest.getCustomEventCount(CUSTOM_TEST_EVENT).toInt())
+            underTest.setCustomEventCount(CUSTOM_TEST_EVENT, 2)
+            assertEquals(2, underTest.getCustomEventCount(CUSTOM_TEST_EVENT).toInt())
+            assertEquals(
+                2,
+                prefsEnv.testSharedPreferences.getInt(
+                    PreferenceHelper.PREF_KEY_CUSTOM_EVENT_PREFIX + CUSTOM_TEST_EVENT,
+                    -1
+                )
+            )
+        }
+    }
+
+    @Test
+    fun testDialogFirstLaunchTime() {
+        PreferenceHelper(
+            InstrumentationRegistry.getInstrumentation().context,
+            prefsEnv.testSharedPreferencesProvider
+        ).also { underTest ->
+            assertEquals(0, underTest.getDialogFirstLaunchTime())
+            underTest.setDialogFirstLaunchTime()
+            assertTrue(underTest.getDialogFirstLaunchTime() > 0)
+            assertTrue(
+                prefsEnv.testSharedPreferences.getLong(
+                    PreferenceHelper.PREF_KEY_DIALOG_FIRST_LAUNCH_TIME,
+                    -1
+                ) > 0
+            )
+        }
+    }
+
+    @Test
+    fun testInstallDate() {
+        val context = InstrumentationRegistry.getInstrumentation().context
+        PreferenceHelper(context, prefsEnv.testSharedPreferencesProvider).also { underTest ->
+            assertEquals(0, underTest.getInstallDate())
+            underTest.setFirstLaunchSharedPreferences(context)
+            assertTrue(underTest.getInstallDate() > 0)
+            assertTrue(
+                prefsEnv.testSharedPreferences.getLong(
+                    PreferenceHelper.PREF_KEY_INSTALL_DATE,
+                    -1
+                ) > 0
+            )
+        }
+    }
+
+    @Test
+    fun testAgreedOrDeclined() {
+        PreferenceHelper(
+            InstrumentationRegistry.getInstrumentation().context,
+            prefsEnv.testSharedPreferencesProvider
+        ).also { underTest ->
+            assertFalse(underTest.getAgreedOrDeclined())
+            underTest.setAgreedOrDeclined(true)
+            assertTrue(underTest.getAgreedOrDeclined())
+            assertTrue(
+                prefsEnv.testSharedPreferences.getBoolean(
+                    PreferenceHelper.PREF_KEY_AGREED_OR_DECLINED,
+                    false
+                )
+            )
+        }
+    }
+
+    @Test
+    fun testLaunchTimes() {
+        PreferenceHelper(
+            InstrumentationRegistry.getInstrumentation().context,
+            prefsEnv.testSharedPreferencesProvider
+        ).also { underTest ->
+            assertEquals(0, underTest.getLaunchTimes().toInt())
+            underTest.setLaunchTimes(333)
+            assertEquals(333, underTest.getLaunchTimes().toInt())
+            assertEquals(
+                333,
+                prefsEnv.testSharedPreferences.getInt(PreferenceHelper.PREF_KEY_LAUNCH_TIMES, -1)
+            )
+        }
+    }
+
+    @Test
+    fun testLastTimeShown() {
+        PreferenceHelper(
+            InstrumentationRegistry.getInstrumentation().context,
+            prefsEnv.testSharedPreferencesProvider
+        ).also { underTest ->
+            assertEquals(0, underTest.getLastTimeShown())
+            underTest.setLastTimeShown()
+            assertTrue(underTest.getLastTimeShown() > 0)
+            assertTrue(
+                prefsEnv.testSharedPreferences.getLong(
+                    PreferenceHelper.PREF_KEY_LAST_TIME_SHOWN,
+                    -1
+                ) > 0
+            )
+        }
+    }
+
+    @Test
+    fun testRemindLaunchesNumber() {
+        PreferenceHelper(
+            InstrumentationRegistry.getInstrumentation().context,
+            prefsEnv.testSharedPreferencesProvider
+        ).also { underTest ->
+            assertEquals(0, underTest.getRemindLaunchesNumber().toInt())
+            underTest.setLaunchTimes(10)
+            underTest.setRemindLaunchesNumber()
+            assertEquals(10, underTest.getRemindLaunchesNumber().toInt())
+            assertEquals(
+                10,
+                prefsEnv.testSharedPreferences.getInt(
+                    PreferenceHelper.PREF_KEY_REMIND_LAUNCHES_NUMBER,
+                    -1
+                )
+            )
+        }
+    }
+
+    @Test
+    fun testClearRemindButtonClick() {
+        PreferenceHelper(
+            InstrumentationRegistry.getInstrumentation().context,
+            prefsEnv.testSharedPreferencesProvider
+        ).also { underTest ->
+            underTest.setLastTimeShown()
+            underTest.setLaunchTimes(3)
+            underTest.setRemindLaunchesNumber()
+
+            underTest.clearRemindButtonClick()
+
+            assertEquals(0, underTest.getLastTimeShown())
+            assertEquals(
+                0,
+                prefsEnv.testSharedPreferences.getLong(
+                    PreferenceHelper.PREF_KEY_LAST_TIME_SHOWN,
+                    -1
+                )
+            )
+            assertEquals(0, underTest.getRemindLaunchesNumber().toInt())
+            assertEquals(
+                0,
+                prefsEnv.testSharedPreferences.getInt(
+                    PreferenceHelper.PREF_KEY_REMIND_LAUNCHES_NUMBER,
+                    -1
+                )
+            )
+        }
+    }
+
+    @Test
+    fun testReminderToShowAgain() {
+        PreferenceHelper(
+            InstrumentationRegistry.getInstrumentation().context,
+            prefsEnv.testSharedPreferencesProvider
+        ).also { underTest ->
+
+            assertEquals(0, underTest.getLastTimeShown())
+            assertEquals(0, underTest.getRemindLaunchesNumber().toInt())
+
+            underTest.setLaunchTimes(1)
+            underTest.setReminderToShowAgain()
+
+            assertTrue(underTest.getLastTimeShown() > 0)
+            assertTrue(
+                prefsEnv.testSharedPreferences.getLong(
+                    PreferenceHelper.PREF_KEY_LAST_TIME_SHOWN,
+                    -1
+                ) > 0
+            )
+
+            assertEquals(1, underTest.getRemindLaunchesNumber().toInt())
+            assertEquals(
+                1,
+                prefsEnv.testSharedPreferences.getInt(
+                    PreferenceHelper.PREF_KEY_REMIND_LAUNCHES_NUMBER,
+                    -1
+                )
+            )
+        }
+    }
+
+    @Test
+    fun testDelay() {
+        PreferenceHelper(
+            InstrumentationRegistry.getInstrumentation().context,
+            prefsEnv.testSharedPreferencesProvider
+        ).also { underTest ->
+            assertEquals(PreferenceHelper.UNSET_DELAY_DATE, underTest.getDelay())
+
+            val testValue = 5.days
+            val testTimeStamp = Date().time + testValue.inWholeMilliseconds
+            underTest.setDelay(5.days)
+            assertTrue(
+                prefsEnv.testSharedPreferences.getLong(
+                    PreferenceHelper.PREF_KEY_DELAY_DATE,
+                    -1
+                ) >= testTimeStamp
+            )
+        }
+    }
+
+    @Test
+    fun testDelayUntil() {
+        PreferenceHelper(
+            InstrumentationRegistry.getInstrumentation().context,
+            prefsEnv.testSharedPreferencesProvider
+        ).also { underTest ->
+            assertEquals(PreferenceHelper.UNSET_DELAY_DATE, underTest.getDelay())
+
+            val testTimeStamp = Date(System.currentTimeMillis() + 5.days.inWholeMilliseconds)
+            underTest.setDelayUntil(testTimeStamp)
+            assertEquals(
+                testTimeStamp.time,
+                prefsEnv.testSharedPreferences.getLong(
+                    PreferenceHelper.PREF_KEY_DELAY_DATE,
+                    -1
+                )
+            )
+        }
+    }
+
+    @Test
+    fun testAddDelay() {
+        PreferenceHelper(
+            InstrumentationRegistry.getInstrumentation().context,
+            prefsEnv.testSharedPreferencesProvider
+        ).also { underTest ->
+            assertEquals(PreferenceHelper.UNSET_DELAY_DATE, underTest.getDelay())
+
+            val testTimeStamp = Date()
+            underTest.setDelayUntil(testTimeStamp)
+            val testDelay = 4000.hours
+            underTest.addDelay(testDelay)
+
+            assertEquals(
+                testTimeStamp.time + testDelay.inWholeMilliseconds,
+                prefsEnv.testSharedPreferences.getLong(
+                    PreferenceHelper.PREF_KEY_DELAY_DATE,
+                    -1
+                )
+            )
+        }
+    }
+}

--- a/library/src/androidTest/java/com/vorlonsoft/android/rate/test_util/PreferencesTestEnv.kt
+++ b/library/src/androidTest/java/com/vorlonsoft/android/rate/test_util/PreferencesTestEnv.kt
@@ -1,0 +1,85 @@
+package com.vorlonsoft.android.rate.test_util
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.vorlonsoft.android.rate.PreferenceHelper
+import org.junit.Assert.assertEquals
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.mockito.stubbing.Answer
+
+class PreferencesTestEnv {
+
+    val testSharedPreferencesMap: MutableMap<String, Any?> = mutableMapOf()
+    var lastPreferencesFile: String? = null
+    val testSharedPreferences: SharedPreferences = mock<SharedPreferences>().apply {
+        // sharedPreferences mock
+        whenever(all).thenAnswer {
+            return@thenAnswer testSharedPreferencesMap
+        }
+        whenever(getString(any(), anyOrNull())).thenAnswer {
+            return@thenAnswer testSharedPreferencesMap[it.arguments[0]] as? String
+                ?: it.arguments[1] as String?
+        }
+        whenever(getStringSet(any(), anyOrNull())).thenAnswer {
+            return@thenAnswer testSharedPreferencesMap[it.arguments[0]] as? Set<String>
+                ?: it.arguments[1]
+        }
+        whenever(getInt(any(), anyOrNull())).thenAnswer {
+            return@thenAnswer testSharedPreferencesMap[it.arguments[0]] as? Int
+                ?: it.arguments[1]
+        }
+        whenever(getLong(any(), anyOrNull())).thenAnswer {
+            return@thenAnswer testSharedPreferencesMap[it.arguments[0]] as? Long
+                ?: it.arguments[1]
+        }
+        whenever(getFloat(any(), anyOrNull())).thenAnswer {
+            return@thenAnswer testSharedPreferencesMap[it.arguments[0]] as? Float
+                ?: it.arguments[1]
+        }
+        whenever(getBoolean(any(), anyOrNull())).thenAnswer {
+            return@thenAnswer testSharedPreferencesMap[it.arguments[0]] as? Boolean
+                ?: it.arguments[1]
+        }
+        whenever(contains(any())).thenAnswer {
+            return@thenAnswer testSharedPreferencesMap.containsKey(it.arguments[0])
+        }
+    }
+    val testSharedPreferencesEditor: SharedPreferences.Editor = mock<SharedPreferences.Editor>().apply {
+        // mock editor
+        val mockAnswer: Answer<SharedPreferences.Editor> = Answer {
+            testSharedPreferencesMap[it.arguments[0] as String] = it.arguments[1]
+            return@Answer this
+        }
+        whenever(putBoolean(any(), any())).thenAnswer(mockAnswer)
+        whenever(putFloat(any(), any())).thenAnswer(mockAnswer)
+        whenever(putInt(any(), any())).thenAnswer(mockAnswer)
+        whenever(putStringSet(any(), any())).thenAnswer(mockAnswer)
+        whenever(putLong(any(), any())).thenAnswer(mockAnswer)
+        whenever(putString(any(), any())).thenAnswer(mockAnswer)
+
+        whenever(clear()).thenAnswer {
+            testSharedPreferencesMap.clear()
+            return@thenAnswer this
+        }
+        whenever(remove(any())).thenAnswer {
+            testSharedPreferencesMap.remove(it.arguments[0] as String)
+            return@thenAnswer this
+        }
+    }
+
+    val testSharedPreferencesProvider: PreferenceHelper.PreferencesProvider = object :
+        PreferenceHelper.PreferencesProvider {
+        override fun getSharedPreferences(
+            context: Context,
+            name: String,
+            mode: Int
+        ): SharedPreferences {
+            whenever(testSharedPreferences.edit()).thenReturn(testSharedPreferencesEditor)
+            lastPreferencesFile = name
+            return testSharedPreferences
+        }
+    }
+}

--- a/library/src/main/java/com/vorlonsoft/android/rate/AppRate.kt
+++ b/library/src/main/java/com/vorlonsoft/android/rate/AppRate.kt
@@ -114,6 +114,8 @@ class AppRate private constructor(context: Context) {
         this.context = context.applicationContext
     }
 
+    private val prefsHelper = PreferenceHelper(context)
+
     private val dialogOptions = DialogOptions()
     private val storeOptions = StoreOptions()
 
@@ -312,7 +314,7 @@ class AppRate private constructor(context: Context) {
      * @return the [AppRate] singleton object
      */
     fun clearRemindButtonClick(): AppRate = apply {
-        PreferenceHelper.clearRemindButtonClick(context)
+        prefsHelper.clearRemindButtonClick()
     }
 
     fun setMinimumEventCount(eventName: String, minimumCount: Short): AppRate = apply {
@@ -422,7 +424,7 @@ class AppRate private constructor(context: Context) {
     }
 
     fun clearSettingsParam(): AppRate = apply {
-        PreferenceHelper.clearSharedPreferences(context)
+        prefsHelper.clearSharedPreferences()
     }
 
     /**
@@ -438,7 +440,7 @@ class AppRate private constructor(context: Context) {
     /**
      * @return true if the rating dialog has been agreed to or declined.
      */
-    fun getAgreedOrDeclinedDialog(): Boolean = PreferenceHelper.getAgreedOrDeclined(context)
+    fun getAgreedOrDeclinedDialog(): Boolean = prefsHelper.getAgreedOrDeclined()
 
     /**
      *
@@ -449,7 +451,7 @@ class AppRate private constructor(context: Context) {
      * @return the [AppRate] singleton object
      */
     fun setAgreedOrDeclinedDialog(agreedOrDeclined: Boolean): AppRate = apply {
-        PreferenceHelper.setAgreedOrDeclined(context, agreedOrDeclined)
+        prefsHelper.setAgreedOrDeclined(agreedOrDeclined)
     }
 
     fun setView(view: View?): AppRate = apply {
@@ -787,12 +789,12 @@ class AppRate private constructor(context: Context) {
     fun incrementEventCount(eventName: String): AppRate {
         return setEventCountValue(
             eventName,
-            (PreferenceHelper.getCustomEventCount(context, eventName) + 1).toShort()
+            (prefsHelper.getCustomEventCount(eventName) + 1).toShort()
         )
     }
 
     fun setEventCountValue(eventName: String, countValue: Short): AppRate = apply {
-        PreferenceHelper.setCustomEventCount(context, eventName, countValue)
+        prefsHelper.setCustomEventCount(eventName, countValue)
     }
 
     /**
@@ -859,7 +861,7 @@ class AppRate private constructor(context: Context) {
      * @return the [AppRate] singleton object
      */
     fun setDelay(delay: Duration): AppRate = apply {
-        PreferenceHelper.setDelay(context, delay)
+        prefsHelper.setDelay(delay)
     }
 
     /**
@@ -870,7 +872,7 @@ class AppRate private constructor(context: Context) {
      * @return the [AppRate] singleton object
      */
     fun addDelay(delay: Duration): AppRate = apply {
-        PreferenceHelper.addDelay(context, delay)
+        prefsHelper.addDelay(delay)
     }
 
     /**
@@ -880,7 +882,7 @@ class AppRate private constructor(context: Context) {
      * @return the [AppRate] singleton object
      */
     fun setDelayUntil(delayDate: Date): AppRate = apply {
-        PreferenceHelper.setDelayUntil(context, delayDate)
+        prefsHelper.setDelayUntil(delayDate)
     }
 
     /**
@@ -891,24 +893,23 @@ class AppRate private constructor(context: Context) {
      * is called.
      */
     fun monitor() {
-        if (PreferenceHelper.isFirstLaunch(context)) {
-            PreferenceHelper.setFirstLaunchSharedPreferences(context)
+        if (prefsHelper.isFirstLaunch()) {
+            prefsHelper.setFirstLaunchSharedPreferences(context)
         } else {
-            PreferenceHelper.setLaunchTimes(
-                context,
-                (PreferenceHelper.getLaunchTimes(context) + 1).toShort()
+            prefsHelper.setLaunchTimes(
+                (prefsHelper.getLaunchTimes() + 1).toShort()
             )
-            if (getLongVersionCode(context) != PreferenceHelper.getVersionCode(context)) {
+            if (getLongVersionCode(context) != prefsHelper.getVersionCode()) {
                 if (isVersionCodeCheck) {
                     setAgreedOrDeclinedDialog(false)
                 }
-                PreferenceHelper.setVersionCode(context)
+                prefsHelper.setVersionCode(context)
             }
-            if (getVersionName(context) != PreferenceHelper.getVersionName(context)) {
+            if (getVersionName(context) != prefsHelper.getVersionName()) {
                 if (isVersionNameCheck) {
                     setAgreedOrDeclinedDialog(false)
                 }
-                PreferenceHelper.setVersionName(context)
+                prefsHelper.setVersionName(context)
             }
         }
 
@@ -1052,30 +1053,28 @@ class AppRate private constructor(context: Context) {
     }
 
     private fun isOverLaunchTimes(): Boolean =
-        appLaunchTimes.toInt() == 0 || PreferenceHelper.getLaunchTimes(context) >= appLaunchTimes
+        appLaunchTimes.toInt() == 0 || prefsHelper.getLaunchTimes() >= appLaunchTimes
 
     private fun isSelectedAppLaunch(): Boolean = selectedAppLaunches.toInt() == 1 ||
-            selectedAppLaunches.toInt() != 0 && PreferenceHelper.getLaunchTimes(context) % selectedAppLaunches == 0
+            selectedAppLaunches.toInt() != 0 && prefsHelper.getLaunchTimes() % selectedAppLaunches == 0
 
     private fun isOverInstallDate(): Boolean =
         installWaitDuration.inWholeMilliseconds == 0L || isOverDate(
-            PreferenceHelper.getInstallDate(context),
+            prefsHelper.getInstallDate(),
             installWaitDuration
         )
 
     private fun isOverRemindDate(): Boolean = remindInterval.inWholeMilliseconds == 0L ||
-            PreferenceHelper.getLastTimeShown(context) == 0L ||
-            isOverDate(PreferenceHelper.getLastTimeShown(context), remindInterval)
+            prefsHelper.getLastTimeShown() == 0L ||
+            isOverDate(prefsHelper.getLastTimeShown(), remindInterval)
 
     private fun isOverRemindLaunchesNumber(): Boolean = remindLaunchesNumber.toInt() == 0 ||
-            PreferenceHelper.getRemindLaunchesNumber(context).toInt() == 0 ||
-            PreferenceHelper.getLaunchTimes(context) - PreferenceHelper.getRemindLaunchesNumber(
-        context
-    ) >= remindLaunchesNumber
+            prefsHelper.getRemindLaunchesNumber().toInt() == 0 ||
+            prefsHelper.getLaunchTimes() - prefsHelper.getRemindLaunchesNumber() >= remindLaunchesNumber
 
     private fun isBelow365DayPeriodMaxNumberDialogLaunchTimes(): Boolean =
         dialogLaunchTimes == Short.MAX_VALUE ||
-                PreferenceHelper.get365DayPeriodDialogLaunchTimes(context) < dialogLaunchTimes
+                prefsHelper.get365DayPeriodDialogLaunchTimes() < dialogLaunchTimes
 
     private fun isOverCustomEventsRequirements(): Boolean {
         if (customEventsCounts.isEmpty()) {
@@ -1083,8 +1082,7 @@ class AppRate private constructor(context: Context) {
         }
         // checking if at least one custom event count is below the expected value
         val unmetCustomEvents = customEventsCounts.entries.firstOrNull {
-            PreferenceHelper.getCustomEventCount(
-                context,
+            prefsHelper.getCustomEventCount(
                 it.key
             ) < it.value
         }
@@ -1092,7 +1090,7 @@ class AppRate private constructor(context: Context) {
         return unmetCustomEvents == null
     }
 
-    private fun isOverDelay() = Date().time > PreferenceHelper.getDelay(context)
+    private fun isOverDelay() = Date().time > prefsHelper.getDelay()
 
     /**
      *
@@ -1160,9 +1158,9 @@ class AppRate private constructor(context: Context) {
             Log.d(TAG, "Google in-app review: flow finished")
             deferredReviewInfo = null
             // updating launch times of dialog
-            PreferenceHelper.dialogShown(context)
+            prefsHelper.dialogShown()
             // we don't know what the user did, always set remind values for next dialog launch
-            PreferenceHelper.setReminderToShowAgain(context)
+            prefsHelper.setReminderToShowAgain()
         }
     }
 }

--- a/library/src/main/java/com/vorlonsoft/android/rate/DefaultDialogManager.java
+++ b/library/src/main/java/com/vorlonsoft/android/rate/DefaultDialogManager.java
@@ -17,7 +17,6 @@ import static android.view.View.VISIBLE;
 import static android.widget.LinearLayout.VERTICAL;
 import static com.vorlonsoft.android.rate.Constants.Utils.TAG;
 import static com.vorlonsoft.android.rate.DialogType.CLASSIC;
-import static com.vorlonsoft.android.rate.PreferenceHelper.dialogShown;
 
 import android.app.AlertDialog;
 import android.app.Dialog;
@@ -81,7 +80,7 @@ public class DefaultDialogManager implements DialogManager {
                     }
                 }
             } else {
-                dialogShown(context);
+                new PreferenceHelper(context).dialogShown();
             }
             if (((SDK_INT >= LOLLIPOP) || (dialog instanceof androidx.appcompat.app.AlertDialog)) &&
                 ((dialogOptions.getType() == CLASSIC) ||

--- a/library/src/main/java/com/vorlonsoft/android/rate/DefaultDialogOnClickListener.java
+++ b/library/src/main/java/com/vorlonsoft/android/rate/DefaultDialogOnClickListener.java
@@ -25,8 +25,6 @@ import static com.vorlonsoft.android.rate.Constants.Utils.EMPTY_STRING;
 import static com.vorlonsoft.android.rate.Constants.Utils.LOG_MESSAGE_PART_1;
 import static com.vorlonsoft.android.rate.Constants.Utils.TAG;
 import static com.vorlonsoft.android.rate.IntentHelper.createIntentsForStore;
-import static com.vorlonsoft.android.rate.PreferenceHelper.setReminderToShowAgain;
-import static com.vorlonsoft.android.rate.PreferenceHelper.setAgreedOrDeclined;
 import static com.vorlonsoft.android.rate.StoreType.AMAZON;
 import static com.vorlonsoft.android.rate.StoreType.APPLE;
 import static com.vorlonsoft.android.rate.StoreType.BAZAAR;
@@ -209,17 +207,17 @@ final class DefaultDialogOnClickListener implements View.OnClickListener,
         } else {
             Log.w(TAG, LOG_MESSAGE_PART_1 + "can't get app package name.");
         }
-        setAgreedOrDeclined(context, true);
+        new PreferenceHelper(context).setAgreedOrDeclined(true);
     }
 
     /** <p>Calls when a negative button on the Rate Dialog is clicked.</p> */
     private void onNegativeButtonClick() {
-        setAgreedOrDeclined(context, true);
+        new PreferenceHelper(context).setAgreedOrDeclined(true);
     }
 
     /** <p>Calls when a neutral button on the Rate Dialog is clicked.</p> */
     private void onNeutralButtonClick() {
-        setReminderToShowAgain(context);
+        new PreferenceHelper(context).setReminderToShowAgain();
     }
 
     /**


### PR DESCRIPTION
- refactoring PreferenceHelper to use a prefs provider, so shared prefs can be mocked in test env